### PR TITLE
Add link to Infermo repo in AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ If you want to contribute, please read [this guide](contributing.md).
 
 * [Modular Engine](https://www.modular.com/engine) - Modular's AI inference engine.
 * [llama2.mojo](https://github.com/tairov/llama2.mojo) - Implementation of llama2.c in Mojo.
+* [Infermo](https://github.com/TilliFe/Infermo) — A compact AutoDiff Engine for Deep Learning
 * [mojograd](https://github.com/automata/mojograd) — Implementation of Karpathy's micrograd in Mojo.
 * [Micro-Mojograd](https://github.com/andresnowak/Micro-Mojograd) - Implementation of Karpathy's micrograd in Mojo.
 * [Mojo-Arrays](https://github.com/MadAlex1997/Mojo-Arrays) - Vectorized N-Dimensional Arrays in native Mojo.


### PR DESCRIPTION
Infermo is a compact AutoDiff Engine specifically designed for Deep Learning. It holds the distinction of being the first public library in pure Mojo capable of training on multidimensional data i.e. tensors. Infermo has been tested on several regression tasks, such as nonlinear function approximation, and classification tasks, including MNIST. Infermo seems like a valuable addition to this list. Thank you very much!