### PR TITLE
Add Lightbug

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ If you want to contribute, please read [this guide](contributing.md).
 
 * [mojo-stdlib-extensions](https://github.com/gabrieldemarmiesse/mojo-stdlib-extensions) - A replica of Python's stdlib in Mojo.
 
+### Web
+
+* [Lightbug](https://github.com/saviorand/lightbug_http) - Simple and fast HTTP and Web framework for Mojo🔥.
+
 ## 📚 Resources
 
 ### Official


### PR DESCRIPTION
**Lightbug** 🪲🔥is a lighweight HTTP framework for Mojo, similar to Starlette in Python or FastHTTP in Golang.

The motivation for this was that I wanted to write APIs in Mojo, but no similar frameworks existed until now. 

We already support setting up a server listening on a host/port, writing custom HTTP services, and more, and working on first benchmarks to measure performance
