### PR TITLE
Updating mojomics URL; present link is invalid 

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ If you want to contribute, please read [this guide](contributing.md).
 
 ### Bioinformatics
 
-* [mojomics](https://github.com/traincheckai/mojomics) - A collection of Jupyter notebooks and resources to empower bioinformatics researchers with the tools and insights they need to accelerate their projects.
 * [MojoFastTrim](https://github.com/MoSafi2/MojoFastTrim) - Experimental 'FASTQ' parser and quality trimmer written in mojo.
 
 ### Database

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ If you want to contribute, please read [this guide](contributing.md).
 ### Bioinformatics
 
 * [MojoFastTrim](https://github.com/MoSafi2/MojoFastTrim) - Experimental 'FASTQ' parser and quality trimmer written in mojo.
+* [mojomics](https://github.com/mattfaltyn/mojomics) - A collection of Jupyter notebooks and resources to empower bioinformatics researchers with the tools and insights they need to accelerate their projects.
 
 ### Database
 


### PR DESCRIPTION
The URL for mojomics does not link to an active repo. 

There is a GitHub repo under the same name, mojomics, here on GitHub and I changed the link to be to that repo. 
I am unsure if the

https://github.com/traincheckai/mojomics is what is currently in the README

https://github.com/mattfaltyn/mojomics what I changed to URL to, although I don't know if this is the same project. 


Hopefully this helps :) 