### PR TITLE
Modo🧯 - Markdown documentation generator (DocGen) for Mojo🔥.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ If you want to contribute, please read [this guide](contributing.md).
 * [menv](https://github.com/mojopaa/menv) - Mojo venv.
 * [mojo-pytest](https://github.com/guidorice/mojo-pytest) - Mojo test runner, pytest plugin (aka pytest-mojo).
 * [mojo-syntax](https://github.com/joelflaig/mojo-syntax) - Mojo🔥 syntax highlighting extension for vim/neovim.
+* [Modo🧯](https://github.com/mlange-42/modo) - Markdown documentation generator (DocGen) for Mojo🔥.
 
 ## 🗂️ Libraries
 


### PR DESCRIPTION
Adds [Modo🧯](https://github.com/mlange-42/modo) to section "Development Tools".

Mojo🔥 does not yet have a DocGen tool, except for `mojo doc`, which just generates JSON. With Modo🧯, there is now a simple yet flexible solution to generate Markdown API docs. These can be used with different publication tools. Currently, besided plain Markdown, [Hugo](https://gohugo.io) and [mdBook](https://rust-lang.github.io/mdBook/) are fully supported.

See Modo🧯's README for more details.