### PR TITLE
Add the Larecs ECS

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ If you want to contribute, please read [this guide](contributing.md).
 ### Games
 
 * [chess.mojo](https://github.com/vietanhdev/chess.mojo) - The first UCI chess engine in Mojo.
+* [Larecs🌲](https://github.com/samufi/larecs) - A performance-oriented archetype-based entity component system (ECS) for Mojo🔥.
 
 ### Math
 


### PR DESCRIPTION
Add the ECS [Larecs](https://github.com/samufi/larecs) to the Games section.

Larecs should be included for the following reasons:
* Larecs is implemented in and for Mojo.
* Larecs is fast and lightweight, with a clean API, unit tests, and benchmarks. 
* Though its list of features and documentation are still growing, Larecs is already fully usable.
* A fast and ergonomic ECS is an important basis for game development and thus of potential interest of users of Awesome Mojo.
* To the best of the author's knowledge, there is no ECS of comparable efficiency and maturity available for Mojo at the moment.