### PR TITLE
Add mimage

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ If you want to contribute, please read [this guide](contributing.md).
 ### Image Processing
 
 * [Jpeg-Decoder](https://github.com/taalhaataahir0102/Jpeg-Decoder) - A compact JPEG image decoder implemented in Mojo🔥.
+* [mimage](https://github.com/fnands/mimage) - An image decoding library implemented in Mojo 🔥. 
 
 ## 📚 Resources<a id='resources'></a>
 


### PR DESCRIPTION
Mimage is an image parsing library written in Mojo that aims to be Mojo's answer to PIL or Scikit-Image. 

There was a bug in 25.1 that stopped me from updating it to the latest Mojo version, but it was fixed, so I am busy updating it to support 25.2. 

