### PR TITLE
Add mojo-dotenv to System section

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ If you want to contribute, please read [this guide](contributing.md).
 ### System
 
 * [mojo-stdlib-extensions](https://github.com/gabrieldemarmiesse/mojo-stdlib-extensions) - A replica of Python's stdlib in Mojo.
+* [mojo-dotenv](https://github.com/databooth/mojo-dotenv) - Load environment variables from `.env` files. 98%+ compatible with python-dotenv. Features variable expansion, multiline values, escape sequences, and auto-discovery. 42 comprehensive tests.
 
 ### Web
 


### PR DESCRIPTION
Hi,

I'd like to add mojo-dotenv to the System section of awesome-mojo.

**mojo-dotenv** is a production-ready .env file parser for Mojo with 98%+ python-dotenv compatibility.

Key features:
- Variable expansion (${VAR} and $VAR)
- Multiline values with triple quotes
- Escape sequences (\n, \r, \t, \\, \', \", \uXXXX)
- Auto-discovery (finds .env files in parent directories)
- 42 comprehensive tests

The package is:
- Available via modular-community (PR merged)
- Well-documented with usage examples
- Tested and production-ready
- Detailed blog post at https://www.databooth.com.au/posts/mojo/building-mojo-dotenv/

Repository: https://github.com/databooth/mojo-dotenv

Thanks for considering this addition!
