### PR TITLE
Add StaMojo & ArgMojo + Update Decimo

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ If you want to contribute, please read [this guide](contributing.md).
 
 * [prism](https://github.com/thatstoasty/prism) - Mojo CLI Library modeled after Cobra.
 * [mog](https://github.com/thatstoasty/mog) - Style definitions for nice terminal layouts.
+* [ArgMojo](https://github.com/forfudan/argmojo) - A command-line argument parser library for Mojo, inspired by Python's `argparse`, Rust's `clap`, and Go's `cobra`, and other popular libraries.
 
 ### Date & Time
 

--- a/README.md
+++ b/README.md
@@ -173,8 +173,9 @@ If you want to contribute, please read [this guide](contributing.md).
 * [Infrared](https://github.com/helehex/infrared) - Geometric Algebra for Mojo🔥.
 * [Specials](https://github.com/leandrolcampos/specials) - Special functions with hardware acceleration.
 * [NuMojo](https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo) - A library for numerical computing in Mojo 🔥 similar to NumPy, SciPy in Python.
-* [DeciMojo](https://github.com/forfudan/decimojo) - An arbitrary-precision decimal and integer mathematics library for Mojo, supporting `BigInt` and `BigDecimal` types.
+* [Decimo](https://github.com/forfudan/decimo) - (formerly DeciMojo) An arbitrary-precision integer and decimal library for Mojo, inspired by Python's ``int`` and ``Decimal``.
 * [SciJo](https://github.com/shivasankarka/SciJo) - A high-performance scientific computing library for Mojo, offering SciPy-like functionality.
+* [StaMojo](https://github.com/mojomath/stamojo) - A statistical computing library for Mojo, inspired by ``scipy.stats`` and ``statsmodels`` in Python.
 
 ### System
 


### PR DESCRIPTION
This PR adds two libraries I am working on:

1. [ArgMojo](https://github.com/forfudan/argmojo), a command-line argument parser library for Mojo, inspired by Python's `argparse`, Rust's `clap`, Go's `cobra`, and other popular libraries.
2. [StaMojo](https://github.com/mojomath/stamojo), a statistical computing library for Mojo, inspired by `scipy.stats` and `statsmodels` in Python.

This PR also updates the description [Decimo](https://github.com/forfudan/decimo) because it was renamed.