### PR TITLE
Add wgpu-mojo binding to 2D/3D Graphics section

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ If you want to contribute, please read [this guide](contributing.md).
 
 ### 2D/3D Graphics
 
+* [wgpu-mojo](https://github.com/Hundo1018/wgpu-mojo) - Wgpu-native binding for Mojo🔥.
 * [mojo-sdl](https://github.com/msteele/mojo-sdl) - Minimal SDL2 binding for Mojo🔥.
 
 ### UI


### PR DESCRIPTION
wgpu-mojo provides Mojo bindings for [wgpu-native](https://github.com/gfx-rs/wgpu-native) (v29), handling C-callback bridging and object lifetime tracking. It also includes a basic GLFW/RenderCanvas wrapper for quick setup.

Technical Highlights:
- Targets wgpu-native v29.
- Includes a GLFW / RenderCanvas wrapper for rapid prototyping.
- Handles internal C-callback bridging and object lifetime tracking.

Repo: https://github.com/Hundo1018/wgpu-mojo