### PR TITLE
Add mojo-kafka

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ If you want to contribute, please read [this guide](contributing.md).
 * [mojo-stdlib-extensions](https://github.com/gabrieldemarmiesse/mojo-stdlib-extensions) - A replica of Python's stdlib in Mojo.
 * [mojo-dotenv](https://github.com/databooth/mojo-dotenv) - Load environment variables from `.env` files. 98%+ compatible with python-dotenv. Features variable expansion, multiline values, escape sequences, and auto-discovery. 42 comprehensive tests.
 * [mojo-toml](https://github.com/databooth/mojo-toml) - TOML 1.0 parser and writer for Mojo. Complete implementation with array-of-tables, alternative number bases, and partial TOML 1.1 support. 168 comprehensive tests.
+* [mojo-kafka](https://github.com/dvirarad/mojo-kafka) - Apache Kafka client for Mojo — librdkafka bindings with a Pythonic producer / consumer / admin API.
 
 ### Web
 


### PR DESCRIPTION
Adding [mojo-kafka](https://github.com/dvirarad/mojo-kafka) — an Apache Kafka client for Mojo backed by `librdkafka` bindings.

Placed under **Libraries > System** since the project is messaging infrastructure. Happy to move it to a new `Messaging` subsection or under `FFI / Interop` if you prefer — let me know.

Format follows the contribution guide: `[name](link) - Description.`, capital start, period end, appended to the bottom of the section.