### PR TITLE
Added Strata to Mojo

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ If you want to contribute, please read [this guide](contributing.md).
 * [Basalt](https://github.com/basalt-org/basalt) - A Machine Learning framework from scratch in Pure Mojo.
 * [Mojmelo](https://github.com/yetalit/Mojmelo) - Machine Learning algorithms in pure Mojo 🔥
 * [mojojojo-agent](https://github.com/lee101/mojojojo-agent) - Open-source coding agent with native search and execution against the mojojojo runtime.
+* [Strata](https://github.com/ethqnol/Strata/) - Machine Learning with Scikit-Learn ergonomics written in Mojo for Mojo. Strict traits, static polymorphism, and generic SIMD types make it extremely fast.
 
 ### CLI
 


### PR DESCRIPTION

Strata is an ML library that has Scikit-Learn ergonomics natively in Mojo without needing to rely on Python interop. As a result, the library can take advantage of Mojo's compile-time metaprogramming, type system, strict traits, and generics to allow Mojo compiler optimizations to squeeze more performance. 

Right now, the library implements:
- Full generic support across varying bit-widths and representations, including Float64, Float32, BFloat16, Int64, and Int32.
- Support for sparse and dense matrices. Linear algebra operations such as QR and Cholesky decomposition use LAPACK/BLAS binding.
- Strict traits for Regressors, Classifiers, Clusterers, and Transformers. All estimator APIs are designed around static polymorphism for better performance and safety. 
- Currently implements Linear Regression, Logistic Regression, Random Forests, Gradient Boosting Trees, K-Means, and Mini-Batch K-Means, alongside basic scalers, normalizers, and evaluation metrics.
- Supports serialization/deserialization for persisting models