### PR TITLE
Add safetensors.mojo

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ If you want to contribute, please read [this guide](contributing.md).
 * [mojo-template](https://github.com/conorbronsdon/mojo-template) - A Jinja-flavored template engine in pure Mojo.
 * [mojo-diff](https://github.com/conorbronsdon/mojo-diff) - Myers text diff and unified-diff output in pure Mojo.
 * [mojo-unicodedata](https://github.com/conorbronsdon/mojo-unicodedata) - Unicode normalization (NFC/NFD/NFKC/NFKD) and casefold in pure Mojo.
+* [safetensors.mojo](https://github.com/egor-fedorov/safetensors.mojo) - Independent Safetensors format implementation in pure Mojo.
 
 ### Web
 


### PR DESCRIPTION
## Summary

Add [safetensors.mojo](https://github.com/egor-fedorov/safetensors.mojo) to **Libraries → Text & Parsing**.

The project is an independent Safetensors format implementation in pure Mojo, with checked validation, local readers, memory-mapped views, and deterministic writing. Version 0.5.0 is available from the [`modular-community`](https://prefix.dev/channels/modular-community/packages/safetensors-mojo) Conda channel.
